### PR TITLE
Archiving verification requests instead of deleting it

### DIFF
--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -1034,6 +1034,12 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return
 		}
+
+		err = helpers.SendDirectMessage(s, user.ID, "You have been verified as an external member of RITSEC. Welcome!", span.Context())
+		if err != nil {
+			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
+			return
+		}
 	case "external":
 		err = s.GuildMemberRoleAdd(i.GuildID, user.ID, externalRole)
 		if err != nil {

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -926,7 +926,7 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 	}
 	defer delete(*ComponentHandlers, denySlug)
 
-	m, err := s.ChannelMessageSendComplex(memberApprovalChannel, &discordgo.MessageSend{
+	_, err = s.ChannelMessageSendComplex(memberApprovalChannel, &discordgo.MessageSend{
 		Embed: &discordgo.MessageEmbed{
 			Title: "Verification request",
 			Fields: []*discordgo.MessageEmbedField{
@@ -1106,11 +1106,5 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return
 		}
-	}
-
-	err = s.ChannelMessageDelete(memberApprovalChannel, m.ID)
-	if err != nil {
-		logging.Error(s, "Error encounted while deleting channel message", user, span, logrus.Fields{"error": err})
-		return
 	}
 }

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -1113,9 +1113,44 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 		}
 	}
 
+	// Delete the initial message and resend the initial message without the buttons
+
 	err = s.ChannelMessageDelete(memberApprovalChannel, m.ID)
 	if err != nil {
 		logging.Error(s, "Error encounted while deleting channel message", user, span, logrus.Fields{"error": err})
+		return
+	}
+
+	_, err = s.ChannelMessageSendComplex(memberApprovalChannel, &discordgo.MessageSend{
+		Embed: &discordgo.MessageEmbed{
+			Title: "ARCHIVED RECORD OF THE Verification request",
+			Fields: []*discordgo.MessageEmbedField{
+				func() *discordgo.MessageEmbedField {
+					if userEmail == "" {
+						return &discordgo.MessageEmbedField{
+							Name:  "email",
+							Value: "Not provided",
+						}
+					} else {
+						return &discordgo.MessageEmbedField{
+							Name:  "email",
+							Value: userEmail,
+						}
+					}
+				}(),
+				{
+					Name:  "Discord",
+					Value: user.Mention(),
+				},
+				{
+					Name:  "Message",
+					Value: message,
+				},
+			},
+		},
+	})
+	if err != nil {
+		logging.Error(s, "Error encounted while sending channel message", user, span, logrus.Fields{"error": err})
 		return
 	}
 }

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -1026,9 +1026,22 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return
+
+		}
+
+		_, err = s.ChannelMessageSend(memberApprovalChannel, fmt.Sprintf("%v verified %v with Member role!", helpers.AtUser(i.Member.User.ID), user.Mention()))
+		if err != nil {
+			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
+			return
 		}
 	case "external":
 		err = s.GuildMemberRoleAdd(i.GuildID, user.ID, externalRole)
+		if err != nil {
+			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
+			return
+		}
+
+		_, err = s.ChannelMessageSend(memberApprovalChannel, fmt.Sprintf("%v verified %v with External role!", helpers.AtUser(i.Member.User.ID), user.Mention()))
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return
@@ -1046,6 +1059,12 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 			return
 		}
 
+		_, err = s.ChannelMessageSend(memberApprovalChannel, fmt.Sprintf("%v verified %v with Prospective role!", helpers.AtUser(i.Member.User.ID), user.Mention()))
+		if err != nil {
+			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
+			return
+		}
+
 		err = helpers.SendDirectMessage(s, user.ID, "You have been verified as a prospective member of RITSEC. Welcome!", span.Context())
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
@@ -1058,6 +1077,12 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 			return
 		}
 
+		_, err = s.ChannelMessageSend(memberApprovalChannel, fmt.Sprintf("%v verified %v with Staff role!", helpers.AtUser(i.Member.User.ID), user.Mention()))
+		if err != nil {
+			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
+			return
+		}
+
 		err = helpers.SendDirectMessage(s, user.ID, "You have been verified as a staff member of RIT. Welcome!", span.Context())
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
@@ -1065,6 +1090,12 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 		}
 	case "alumni":
 		err = s.GuildMemberRoleAdd(i.GuildID, user.ID, alumniRole)
+		if err != nil {
+			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
+			return
+		}
+
+		_, err = s.ChannelMessageSend(memberApprovalChannel, fmt.Sprintf("%v verified %v with Alumni role!", helpers.AtUser(i.Member.User.ID), user.Mention()))
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -926,7 +926,7 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 	}
 	defer delete(*ComponentHandlers, denySlug)
 
-	_, err = s.ChannelMessageSendComplex(memberApprovalChannel, &discordgo.MessageSend{
+	m, err := s.ChannelMessageSendComplex(memberApprovalChannel, &discordgo.MessageSend{
 		Embed: &discordgo.MessageEmbed{
 			Title: "Verification request",
 			Fields: []*discordgo.MessageEmbedField{
@@ -1111,5 +1111,11 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return
 		}
+	}
+
+	err = s.ChannelMessageDelete(memberApprovalChannel, m.ID)
+	if err != nil {
+		logging.Error(s, "Error encounted while deleting channel message", user, span, logrus.Fields{"error": err})
+		return
 	}
 }

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -1034,7 +1034,7 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 			return
 		}
 
-		err = helpers.SendDirectMessage(s, user.ID, "You have been verified as an external member of RITSEC. Welcome!", span.Context())
+		err = helpers.SendDirectMessage(s, user.ID, "You have been verified as a member of RITSEC. Welcome!", span.Context())
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -1026,7 +1026,6 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return
-
 		}
 
 		_, err = s.ChannelMessageSend(memberApprovalChannel, fmt.Sprintf("%v verified %v with Member role!", helpers.AtUser(i.Member.User.ID), user.Mention()))


### PR DESCRIPTION
Currently, the member approval deletes the verification request when the Eboard clicks on one of the buttons

This new codes instead archives and verifies which Eboard did the approval

![image](https://github.com/ritsec/ops-bot-iii/assets/39505290/8a8ac491-1df1-492e-a52e-02ca8ddfa4ea)
