### PR TITLE
Fixed /member not giving Member role and added more response messages

### DIFF
--- a/commands/main.go
+++ b/commands/main.go
@@ -58,7 +58,6 @@ func Init(ctx ddtrace.SpanContext) {
 	// Attach events to bot
 	addSlashCommands(span.Context())
 	addHandlers(span.Context())
-	logging.Debug(bot.Session, "Finished init", nil, span)
 }
 
 // addSlashCommands adds all slash commands to the bot

--- a/commands/main.go
+++ b/commands/main.go
@@ -58,6 +58,7 @@ func Init(ctx ddtrace.SpanContext) {
 	// Attach events to bot
 	addSlashCommands(span.Context())
 	addHandlers(span.Context())
+	logging.Debug(bot.Session, "Finished init", nil, span)
 }
 
 // addSlashCommands adds all slash commands to the bot

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -176,6 +176,15 @@ func Member() (*discordgo.ApplicationCommand, func(s *discordgo.Session, i *disc
 						return
 					}
 
+					msg := "You have been verified as a member of RITSEC. Welcome!"
+					_, err = s.InteractionResponseEdit(originalInteraction.Interaction, &discordgo.WebhookEdit{
+						Content: &msg,
+					})
+					if err != nil {
+						logging.Error(s, err.Error(), originalInteraction.User, span, logrus.Fields{"error": err})
+						return
+					}
+
 				} else {
 					manualVerification(s, i, userEmail, attempts, span.Context())
 					return

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -872,6 +872,7 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 
 	message := <-verifyChan
 	i = <-interactionCreateChan
+	orginalInteraction := i
 
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
@@ -922,6 +923,7 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 		memberChan <- "alumni"
 		interactionCreateChan <- i
 	}
+	defer delete(*ComponentHandlers, alumniSlug)
 
 	(*ComponentHandlers)[denySlug] = func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		memberChan <- "deny"
@@ -1034,7 +1036,7 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 
 	switch memberType {
 	case "member":
-		err = addMemberRole(s, i, userEmail, attempts, false, span.Context())
+		err = addMemberRole(s, orginalInteraction, userEmail, attempts, false, span.Context())
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -170,7 +170,7 @@ func Member() (*discordgo.ApplicationCommand, func(s *discordgo.Session, i *disc
 					}
 
 					// add member role
-					err = addMemberRole(s, i, userEmail, attempts, span.Context())
+					err = addMemberRole(s, originalInteraction, userEmail, attempts, span.Context())
 					if err != nil {
 						logging.Error(s, err.Error(), originalInteraction.Member.User, span, logrus.Fields{"error": err})
 						return

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -375,23 +375,6 @@ func addMemberRole(s *discordgo.Session, i *discordgo.InteractionCreate, userEma
 	}
 
 	logging.Debug(s, fmt.Sprintf("User successfully verified:\n Email:`%v`\nAttempts:`%d`", userEmail, attempts), i.Member.User, span)
-
-	// if firstMessage {
-	// 	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-	// 		Type: discordgo.InteractionResponseChannelMessageWithSource,
-	// 		Data: &discordgo.InteractionResponseData{
-	// 			Flags:   discordgo.MessageFlagsEphemeral,
-	// 			Content: "You have been verified as a member of RITSEC. Welcome!",
-	// 		},
-	// 	})
-	// } else {
-	// 	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-	// 		Type: discordgo.InteractionResponseUpdateMessage,
-	// 		Data: &discordgo.InteractionResponseData{
-	// 			Content: "You have been verified as a member of RITSEC. Welcome!",
-	// 		},
-	// 	})
-	// }
 	return nil
 }
 
@@ -495,7 +478,7 @@ func recievedEmail(s *discordgo.Session, i *discordgo.InteractionCreate, userEma
 	err := s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
 		Data: &discordgo.InteractionResponseData{
-			Content: "A verification code has been sent to \"" + userEmail + "\". This could take up to 10 minutes. **Do not close discord or this window will be closed**.",
+			Content: "A verification code has been sent to \"" + userEmail + "\". This could take up to 10 minutes and could be in your spam. Please check your spam! **Do not close discord or this window will be closed**.",
 			Components: []discordgo.MessageComponent{
 				discordgo.ActionsRow{
 					Components: []discordgo.MessageComponent{

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -449,6 +449,16 @@ func getVerificationCode(s *discordgo.Session, i *discordgo.InteractionCreate, c
 	verificationCode := <-verifyChan
 	i = <-interactionCreateChan
 
+	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Content: "Verification code received. Please wait while we verify...",
+		},
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
 	return verificationCode, i, nil
 }
 

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -56,7 +56,7 @@ func Member() (*discordgo.ApplicationCommand, func(s *discordgo.Session, i *disc
 
 			// check if user is already a member
 			if data.User.IsVerified(i.Member.User.ID, span.Context()) {
-				err := addMemberRole(s, i, "", 0, true, span.Context())
+				err := addMemberRole(s, i, "", 0, span.Context())
 				if err != nil {
 					logging.Error(s, err.Error(), i.Member.User, span, logrus.Fields{"error": err})
 					return
@@ -170,7 +170,7 @@ func Member() (*discordgo.ApplicationCommand, func(s *discordgo.Session, i *disc
 					}
 
 					// add member role
-					err = addMemberRole(s, i, userEmail, attempts, false, span.Context())
+					err = addMemberRole(s, i, userEmail, attempts, span.Context())
 					if err != nil {
 						logging.Error(s, err.Error(), originalInteraction.Member.User, span, logrus.Fields{"error": err})
 						return
@@ -348,7 +348,7 @@ func emailInUse(s *discordgo.Session, i *discordgo.InteractionCreate, userEmail 
 }
 
 // addMemberRole adds the member role to the user and marks them as verified
-func addMemberRole(s *discordgo.Session, i *discordgo.InteractionCreate, userEmail string, attempts int, firstMessage bool, ctx ddtrace.SpanContext) error {
+func addMemberRole(s *discordgo.Session, i *discordgo.InteractionCreate, userEmail string, attempts int, ctx ddtrace.SpanContext) error {
 	span := tracer.StartSpan(
 		"commands.slash.member:addMemberRole",
 		tracer.ResourceName("/member:addMemberRole"),
@@ -375,22 +375,24 @@ func addMemberRole(s *discordgo.Session, i *discordgo.InteractionCreate, userEma
 	}
 
 	logging.Debug(s, fmt.Sprintf("User successfully verified:\n Email:`%v`\nAttempts:`%d`", userEmail, attempts), i.Member.User, span)
-	if firstMessage {
-		return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseChannelMessageWithSource,
-			Data: &discordgo.InteractionResponseData{
-				Flags:   discordgo.MessageFlagsEphemeral,
-				Content: "You have been verified as a member of RITSEC. Welcome!",
-			},
-		})
-	} else {
-		return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-			Type: discordgo.InteractionResponseUpdateMessage,
-			Data: &discordgo.InteractionResponseData{
-				Content: "You have been verified as a member of RITSEC. Welcome!",
-			},
-		})
-	}
+
+	// if firstMessage {
+	// 	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	// 		Type: discordgo.InteractionResponseChannelMessageWithSource,
+	// 		Data: &discordgo.InteractionResponseData{
+	// 			Flags:   discordgo.MessageFlagsEphemeral,
+	// 			Content: "You have been verified as a member of RITSEC. Welcome!",
+	// 		},
+	// 	})
+	// } else {
+	// 	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	// 		Type: discordgo.InteractionResponseUpdateMessage,
+	// 		Data: &discordgo.InteractionResponseData{
+	// 			Content: "You have been verified as a member of RITSEC. Welcome!",
+	// 		},
+	// 	})
+	// }
+	return nil
 }
 
 // getVerificationCode sends the user a verification code and waits for them to respond with it
@@ -1037,7 +1039,7 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 
 	switch memberType {
 	case "member":
-		err = addMemberRole(s, originalInteraction, userEmail, attempts, false, span.Context())
+		err = addMemberRole(s, originalInteraction, userEmail, attempts, span.Context())
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/google/uuid"
@@ -403,11 +404,14 @@ func getVerificationCode(s *discordgo.Session, i *discordgo.InteractionCreate, c
 	verifyChan := make(chan string)
 	defer close(verifyChan)
 
+	done := make(chan bool)
+	defer close(done)
+
 	verifySlug := uuid.New().String()
 
 	(*ComponentHandlers)[verifySlug] = func(s *discordgo.Session, i *discordgo.InteractionCreate) {
 		data := i.ModalSubmitData()
-
+		done <- true
 		verifyChan <- data.Components[0].(*discordgo.ActionsRow).Components[0].(*discordgo.TextInput).Value
 		interactionCreateChan <- i
 	}
@@ -438,20 +442,38 @@ func getVerificationCode(s *discordgo.Session, i *discordgo.InteractionCreate, c
 		return "", nil, err
 	}
 
-	verificationCode := <-verifyChan
-	i = <-interactionCreateChan
+	// verificationCode := <-verifyChan
+	// i = <-interactionCreateChan
 
-	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
-		Type: discordgo.InteractionResponseUpdateMessage,
-		Data: &discordgo.InteractionResponseData{
-			Content: "Verification code received. Please wait while we verify...",
-		},
-	})
-	if err != nil {
-		return "", nil, err
+	// err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	// 	Type: discordgo.InteractionResponseUpdateMessage,
+	// 	Data: &discordgo.InteractionResponseData{
+	// 		Content: "Verification code received. Please wait while we verify...",
+	// 	},
+	// })
+	// if err != nil {
+	// 	return "", nil, err
+	// }
+
+	// return verificationCode, i, nil
+	for {
+		select {
+		case verificationCode := <-verifyChan:
+			i = <-interactionCreateChan
+			err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+				Type: discordgo.InteractionResponseUpdateMessage,
+				Data: &discordgo.InteractionResponseData{
+					Content: "Verification code received. Please wait while we verify...",
+				},
+			})
+			if err != nil {
+				return "", nil, err
+			}
+			return verificationCode, i, nil
+		case <-time.After(1 * time.Minute): // Adjust timeout as needed
+			return "", nil, fmt.Errorf("interaction timed out")
+		}
 	}
-
-	return verificationCode, i, nil
 }
 
 // recievedEmail will prompt a user to check if they recieved an email

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -870,9 +870,10 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 		return
 	}
 
+	originalInteraction := i
+
 	message := <-verifyChan
 	i = <-interactionCreateChan
-	orginalInteraction := i
 
 	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseUpdateMessage,
@@ -1036,7 +1037,7 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 
 	switch memberType {
 	case "member":
-		err = addMemberRole(s, orginalInteraction, userEmail, attempts, false, span.Context())
+		err = addMemberRole(s, originalInteraction, userEmail, attempts, false, span.Context())
 		if err != nil {
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return

--- a/commands/slash/member.go
+++ b/commands/slash/member.go
@@ -1050,6 +1050,15 @@ func manualVerification(s *discordgo.Session, i *discordgo.InteractionCreate, us
 			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
 			return
 		}
+
+		msg := "You have been verified as a member of RITSEC. Welcome!"
+		_, err = s.InteractionResponseEdit(originalInteraction.Interaction, &discordgo.WebhookEdit{
+			Content: &msg,
+		})
+		if err != nil {
+			logging.Error(s, err.Error(), user, span, logrus.Fields{"error": err})
+			return
+		}
 	case "external":
 		err = s.GuildMemberRoleAdd(i.GuildID, user.ID, externalRole)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -47,6 +47,8 @@ func main() {
 	// start scheduled tasks
 	commands.StartScheduledTasks(span.Context())
 
+	logging.Debug(bot.Session, "Finished init", nil, span)
+
 	// create stop channel
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt)


### PR DESCRIPTION
- Preserved the the original interaction to be passed into the addMemberRole()
- Removed first message function
- Added a reminder to check spam in the verification code message
- Added missing defer delete for alumniSlug
- Added a debug message when all of the initialization is done after bot startup for QoL