### PR TITLE
Temporarily disable accounts on sign-up

### DIFF
--- a/osclient/user.go
+++ b/osclient/user.go
@@ -154,7 +154,7 @@ func Create(email string) (string, string, error) {
 	// Create Project
 	createOpts := projects.CreateOpts{
 		DomainID: "default",
-		Enabled:  gophercloud.Enabled,
+		Enabled:  gophercloud.Disabled,
 		Name:     username,
 	}
 


### PR DESCRIPTION
While the stack is restricted to just black team, we should have new accounts automatically be disabled on creation